### PR TITLE
chore(ci): Add wei/pull configuration file

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,6 @@
+version: "1"
+rules:
+  - base: upstream
+    upstream: BezaluLLC:main
+    mergeMethod: hardreset
+    mergeUnstable: true


### PR DESCRIPTION
This pull request introduces a new configuration file, `.github/pull.yml`, which serves as the defaults for forks to stay synchronized with upstream (this repo). This change helps streamline the process of keeping downstream codebases up-to-date with the main branch.

Repository synchronization configuration:

* Added `.github/pull.yml` to define rules for syncing with the `BezaluLLC:main` upstream branch, specifying a `hardreset` merge method and enabling `mergeUnstable`.